### PR TITLE
Added support for methods overloading

### DIFF
--- a/EntityFramework.Functions.Tests/Examples/BuiltInFunctions.cs
+++ b/EntityFramework.Functions.Tests/Examples/BuiltInFunctions.cs
@@ -1,8 +1,22 @@
-﻿namespace EntityFramework.Functions.Tests.Examples
+﻿using System;
+
+namespace EntityFramework.Functions.Tests.Examples
 {
     public static class BuiltInFunctions
     {
         [BuiltInFunction("LEFT")]
         public static string Left(this string value, int count) => Function.CallNotSupported<string>();
+
+        [BuiltInFunction("SWITCHOFFSET")]
+        public static DateTimeOffset? SwitchOffset(DateTimeOffset? dateTimeOffset, int offsetValue)
+        {
+            return Function.CallNotSupported<DateTimeOffset?>();
+        }
+
+        [BuiltInFunction("SWITCHOFFSET")]
+        public static DateTimeOffset SwitchOffset(DateTimeOffset dateTimeOffset, int offsetValue)
+        {
+            return Function.CallNotSupported<DateTimeOffset>();
+        }
     }
 }

--- a/EntityFramework.Functions/Function.DbModel.cs
+++ b/EntityFramework.Functions/Function.DbModel.cs
@@ -123,6 +123,14 @@ namespace EntityFramework.Functions
                 functionName = methodInfo.Name;
             }
 
+            //Fix (rodro75): functions could be added several times here in case of methods overloading, 
+            //which is necessary in some scenarios, but we should really add the metadata just once or EF
+            //would complain when compiling the model.
+            //Not shure about "Ordinal" equality though.. shouldn't it be OrdinalIgnoreCase instead?
+            //As far as I know function names are not case-sensitive in SQL Server.
+            if (model.StoreModel.Functions.Any(x => x.Name.EqualsOrdinal(functionName)))
+                return;
+
             EdmFunction storeFunction = EdmFunction.Create(
                 functionName,
                 FunctionAttribute.CodeFirstDatabaseSchema, // model.StoreModel.Container.Name is always "CodeFirstDatabaseSchema".


### PR DESCRIPTION
Hey Dixin, thanks for the great work!

I was having troubles in my scenario because I wanted to overload the method in C#, but that resulted in a duplicate definition in the dbModel.

So I just added a check in the AddFunction method and exit if it's been already registered.

-Rodrigo-