### PR TITLE
Add StoreFunctionName to support Oracle Package calls.

### DIFF
--- a/EntityFramework.Functions/Function.DbModel.cs
+++ b/EntityFramework.Functions/Function.DbModel.cs
@@ -136,6 +136,7 @@ namespace EntityFramework.Functions
                 new EdmFunctionPayload()
                 {
                     Schema = functionAttribute.Schema,
+                    StoreFunctionName = functionAttribute.StoreFunctionName,
                     IsAggregate = functionAttribute.IsAggregate,
                     IsBuiltIn = functionAttribute.IsBuiltIn,
                     IsNiladic = functionAttribute.IsNiladic,

--- a/EntityFramework.Functions/FunctionAttribute.cs
+++ b/EntityFramework.Functions/FunctionAttribute.cs
@@ -124,6 +124,8 @@
         public string Schema { get; set; }
 
         public ParameterTypeSemantics ParameterTypeSemantics { get; set; } = ParameterTypeSemantics.AllowImplicitConversion;
+
+        public string StoreFunctionName { get; set; }
     }
 
     public class StoredProcedureAttribute : FunctionAttribute


### PR DESCRIPTION
Keep StoreFunctionName to function metadata in order to support Oracle Package calls of the form:
`USERNAME.PACKAGE.PACKAGE_METHOD `
such as:
`HR.Employees.GetEmployees`
