### PR TITLE
Fix nuspec

### DIFF
--- a/Tools/EntityFramework.Functions.nuspec
+++ b/Tools/EntityFramework.Functions.nuspec
@@ -35,9 +35,6 @@ For more information, see:
       <group targetFramework=".NETStandard2.1">
         <dependency id="EntityFramework" version="6.4.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework=".NETFramework4.0">
-        <dependency id="EntityFramework" version="6.1.0" />
-      </group>
       <group targetFramework=".NETFramework4.5">
         <dependency id="EntityFramework" version="6.1.0" />
       </group>
@@ -53,10 +50,9 @@ For more information, see:
     </dependencies>
   </metadata>
   <files>
-    <file src="..\EntityFramework.Functions.Net48\bin\Release\EntityFramework.Functions.dll" target="lib\net40\EntityFramework.Functions.dll" />
-    <file src="..\EntityFramework.Functions.Net48\bin\Release\EntityFramework.Functions.dll" target="lib\net45\EntityFramework.Functions.dll" />
-    <file src="..\EntityFramework.Functions.Net48\bin\Release\EntityFramework.Functions.dll" target="lib\net46\EntityFramework.Functions.dll" />
-    <file src="..\EntityFramework.Functions.Net48\bin\Release\EntityFramework.Functions.dll" target="lib\net47\EntityFramework.Functions.dll" />
+    <file src="..\EntityFramework.Functions.Net45\bin\Release\EntityFramework.Functions.dll" target="lib\net45\EntityFramework.Functions.dll" />
+    <file src="..\EntityFramework.Functions.Net46\bin\Release\EntityFramework.Functions.dll" target="lib\net46\EntityFramework.Functions.dll" />
+    <file src="..\EntityFramework.Functions.Net47\bin\Release\EntityFramework.Functions.dll" target="lib\net47\EntityFramework.Functions.dll" />
     <file src="..\EntityFramework.Functions.Net48\bin\Release\EntityFramework.Functions.dll" target="lib\net48\EntityFramework.Functions.dll" />
     <file src="..\EntityFramework.Functions.NetStandard\bin\Release\netstandard2.1\EntityFramework.Functions.dll" target="lib\netstandard2.1\EntityFramework.Functions.dll" />
   </files>


### PR DESCRIPTION
The nuget package is currently broken under .Net Framework 4.5/4.6/4.7 because the packaged dll is always the 4.8 version which is not compatible with these frameworks.